### PR TITLE
Bug - URL too long

### DIFF
--- a/src/main/groovy/com/metalr2/butler/model/release/ReleaseEntity.groovy
+++ b/src/main/groovy/com/metalr2/butler/model/release/ReleaseEntity.groovy
@@ -34,10 +34,10 @@ class ReleaseEntity extends BaseEntity implements Comparable<ReleaseEntity> {
   @Enumerated(EnumType.STRING)
   ReleaseType type
 
-  @Column(name = "metal_archives_artist_url", nullable = true)
+  @Column(name = "metal_archives_artist_url", nullable = true, length = 500)
   URL metalArchivesArtistUrl
 
-  @Column(name = "metal_archives_album_url", nullable = true)
+  @Column(name = "metal_archives_album_url", nullable = true, length = 500)
   URL metalArchivesAlbumUrl
 
   @Column(name = "source", nullable = true)


### PR DESCRIPTION
We had the standard length of 255 chars ont the url columns. We had one example that exceeded this. So URLs saved to the database can now be up to 500 characters long.